### PR TITLE
Update setup.py sepating test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,14 @@ AUTHOR = 'Mike Overby'
 
 # What packages are required for this module to be executed?
 REQUIRED = [
-    'unicards==0.6',
+    'unicards==0.6'
+
+]
+
+# What packages are required for running the test suite?
+# To install them run for bas : "pip install .[test]"
+# for zsh, run "pip install.\[test\]"
+TEST_REQUIRED = [
     'pytest==3.2.1'
 ]
 
@@ -46,7 +53,7 @@ class PublishCommand(Command):
 
     description = 'Build and publish the package.'
     user_options = []
-    
+
     @staticmethod
     def status(s):
         """Prints things in bold."""
@@ -91,6 +98,9 @@ setup(
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
+    extras_require={
+        'test':TEST_REQUIRED
+    },
     include_package_data=True,
     license='MIT',
     classifiers=[
@@ -103,7 +113,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
-    # $ setup.py publish support. 
+    # $ setup.py publish support.
     cmdclass={
         'publish': PublishCommand,
     },

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,8 @@
 * Hand detection, with nicknames
 * Separate tests from code
 * Test every method
+* setup a CI (like Travis CI)
+* add "usage" and "Development setup" to README
 * Implement a game with spydes
 * Document each method
 * Implement `__cmp__` for cards


### PR DESCRIPTION
Separate test dependencies from main install requirements.
And add more tasks in TODO.md

the **`setup.py`** can be more PEP8-fied. But it's up to you.
And the development setup instrauction can/should be added to **`README.rst`** or **`CONTRIBUTING.md`**.

Let me know if you want any change in PR.